### PR TITLE
Add csv export option

### DIFF
--- a/z/entry.go
+++ b/z/entry.go
@@ -106,10 +106,10 @@ func (entry *Entry) SetFinishFromString(finish string) (time.Time, error) {
 
 
 func (entry *Entry) GetCSVHeaderAllData() []string { 
-	return []string{"date", "begin", "finish", "project", "hours", "task", "notes"}	
+	return []string{"date", "begin", "finish", "project", "task", "hours", "notes"}	
 }
 func (entry *Entry) GetCSVHeaderShortData() []string { 
-	return []string{"date", "project", "hours", "task"}	
+	return []string{"date", "project", "task", "hours"}	
 }
 
 func (entry *Entry) IsFinishedAfterBegan() bool {
@@ -158,8 +158,8 @@ func (entry *Entry) ConvertToCSVAllData() []string {
 		entry.Begin.String(), 
 		entry.Finish.String(), 
 		entry.Project,
-		entry.Hours,
 		entry.Task,
+		entry.Hours,
 		entry.Notes,
 	}
 }
@@ -168,8 +168,8 @@ func (entry *Entry) ConvertToCSVShortData() []string {
 	return []string{
 		entry.Date, 
 		entry.Project,
-		entry.Hours,
 		entry.Task,
+		entry.Hours,
 	}
 }
 

--- a/z/entry.go
+++ b/z/entry.go
@@ -104,6 +104,14 @@ func (entry *Entry) SetFinishFromString(finish string) (time.Time, error) {
 	return finishTime, nil
 }
 
+
+func (entry *Entry) GetCSVHeaderAllData() []string { 
+	return []string{"date", "begin", "finish", "project", "hours", "task", "notes"}	
+}
+func (entry *Entry) GetCSVHeaderShortData() []string { 
+	return []string{"date", "project", "hours", "task"}	
+}
+
 func (entry *Entry) IsFinishedAfterBegan() bool {
 	return (entry.Finish.IsZero() || entry.Begin.Before(entry.Finish))
 }
@@ -142,6 +150,27 @@ func (entry *Entry) GetDuration() decimal.Decimal {
 		duration = time.Since(entry.Begin)
 	}
 	return decimal.NewFromFloat(duration.Hours())
+}
+
+func (entry *Entry) ConvertToCSVAllData() []string {
+	return []string{
+		entry.Date, 
+		entry.Begin.String(), 
+		entry.Finish.String(), 
+		entry.Project,
+		entry.Hours,
+		entry.Task,
+		entry.Notes,
+	}
+}
+
+func (entry *Entry) ConvertToCSVShortData() []string {
+	return []string{
+		entry.Date, 
+		entry.Project,
+		entry.Hours,
+		entry.Task,
+	}
 }
 
 func (entry *Entry) GetOutputForFinish() string {

--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -39,6 +39,7 @@ func exportCSV(entries []Entry) error {
 	}
 	defer f.Close()
 	csvWriter := csv.NewWriter(f)
+	csvWriter.Comma = ';'
 	if exportAllFields { 
 		err := csvWriter.Write(entries[0].GetCSVHeaderAllData())
 		if err != nil {
@@ -63,6 +64,7 @@ func exportCSV(entries []Entry) error {
 			}
 		}
 	}
+	csvWriter.Flush()
 	return nil 
 }
 

--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"encoding/csv"
 
 	"github.com/jinzhu/now"
 	"github.com/spf13/cobra"
@@ -27,6 +28,42 @@ func exportTymeJson(entries []Entry) (string, error) {
 	}
 
 	return tyme.Stringify(), nil
+}
+
+
+func exportCSV(entries []Entry) error { 
+	// TODO: There has to be a nicer way to write this, for now this is okay.
+	f, err := os.OpenFile(fileName, os.O_CREATE| os.O_APPEND | os.O_WRONLY, 0666)
+	if err != nil {
+		return err 
+	}
+	defer f.Close()
+	csvWriter := csv.NewWriter(f)
+	if exportAllFields { 
+		err := csvWriter.Write(entries[0].GetCSVHeaderAllData())
+		if err != nil {
+			return err 
+		}
+	} else {
+		err := csvWriter.Write(entries[0].GetCSVHeaderShortData())
+		if err != nil {
+			return err 
+		}
+	}
+	for _, v := range entries {
+		if exportAllFields {
+			err := csvWriter.Write(v.ConvertToCSVAllData())
+			if err != nil {
+				return err 
+			}
+		} else {
+			err := csvWriter.Write(v.ConvertToCSVShortData())
+			if err != nil {
+				return err 
+			}
+		}
+	}
+	return nil 
 }
 
 var exportCmd = &cobra.Command{
@@ -89,6 +126,12 @@ var exportCmd = &cobra.Command{
 
 		var output = ""
 		switch format {
+		case "csv": 
+			err = exportCSV(filteredEntries)
+			if err != nil {
+				fmt.Printf("%s %+v\n", CharError, err)
+				os.Exit(1)
+			}
 		case "zeit":
 			output, err = exportZeitJson(filteredEntries)
 			if err != nil {
@@ -110,6 +153,8 @@ var exportCmd = &cobra.Command{
 	},
 }
 
+
+
 func init() {
 	rootCmd.AddCommand(exportCmd)
 	exportCmd.Flags().StringVar(&format, "format", "zeit", "Format to export, possible values: zeit, tyme")
@@ -117,8 +162,10 @@ func init() {
 	exportCmd.Flags().StringVar(&until, "until", "", "Date/time to export until")
 	exportCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be exported")
 	exportCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be exported")
-	exportCmd.Flags().BoolVar(&exportDate, "date", false, "Set to true, if you want to export the 'Date' aswell")
-	exportCmd.Flags().BoolVar(&exportHours, "hours-decimal", false, "Set to true if you want calculated Hours to be exported too")
+	exportCmd.Flags().BoolVar(&exportDate, "date", true, "Set to true, if you want to export the 'Date' aswell")
+	exportCmd.Flags().BoolVar(&exportHours, "hours-decimal", true, "Set to true if you want calculated Hours to be exported too")
+	exportCmd.Flags().StringVar(&fileName, "file-name", "", "Set the output file for the csv export")
+	exportCmd.Flags().BoolVar(&exportAllFields, "export-all-fields", false, "Set to true if you want to export all the available fields to the csv")
 
 	var err error
 	database, err = InitDatabase()

--- a/z/rootCmd.go
+++ b/z/rootCmd.go
@@ -17,6 +17,8 @@ var task string
 var notes string
 var exportDate bool
 var exportHours bool
+var fileName string
+var exportAllFields bool
 
 var since string
 var until string

--- a/z/util.go
+++ b/z/util.go
@@ -18,7 +18,7 @@ func fmtHours(hours decimal.Decimal) string {
 		return hours.StringFixed(2)
 	} else {
 		return fmt.Sprintf(
-			"%s:%02s",
+			"%s,%02s",
 			hours.Floor(), // hours
 			hours.Sub(hours.Floor()).
 				Mul(decimal.NewFromFloat(.6)).


### PR DESCRIPTION
Added a 'csv' export format. 

Can be accessed via `format -- "csv"`  

Needs some added things though but I implement that later. 

TODO: 

- Add warning/error when you have 'csv' format but no filename specified. 
- Add warning/error when you supply file that already exists 